### PR TITLE
Fixed instalation instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _note the UCSUR are just a square for me because my font doesn't support them, b
 
 ## Installation
 
-Using `cargo`: `cargo install --git https://Brian3647/seme`
+Using `cargo`: `cargo install --git https://github.com/Brian3647/seme`
 
 ## Usage
 


### PR DESCRIPTION
There was https://Brian3647/seme instead of https://**github.com**/Brian3647/seme