### PR TITLE
Implemented caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +206,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +290,17 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -357,6 +395,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -498,6 +553,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +593,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "dirs",
  "isahc",
  "linku-sona",
  "serde",
@@ -600,6 +676,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -708,6 +804,12 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.1", features = ["derive"] }
 colored = "2.1.0"
+dirs = "5.0.1"
 isahc = "1.7.2"
 linku-sona = "0.1"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,60 @@
+use crate::error::Error;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fs, time::SystemTime};
+//cache lifetime is 1 month
+const CACHE_LIFETIME_SECONDS: u64 = 2_628_288;
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
+struct CacheEntry {
+	content: String,
+	created: SystemTime,
+}
+
+pub fn add_cache(url: String, result: String) -> Result<(), Error> {
+	let mut cache = read_cache_file();
+	cache.insert(
+		url,
+		CacheEntry {
+			content: result,
+			created: SystemTime::now(),
+		},
+	);
+	write_to_cache(cache)
+}
+
+#[allow(unused_must_use)]
+pub fn get_from_cache(url: &String) -> Result<Option<String>, Error> {
+	let mut cache = read_cache_file();
+	if let Some(entry) = cache.get(url) {
+		if SystemTime::now().duration_since(entry.created).unwrap()
+			<= std::time::Duration::from_secs(CACHE_LIFETIME_SECONDS)
+		{
+			return Ok(Some(entry.content.clone()));
+		}
+
+		cache.remove(url);
+		write_to_cache(cache);
+	}
+
+	Ok(None)
+}
+
+fn get_cachefile_path() -> std::path::PathBuf {
+	let mut cachefile_path = dirs::cache_dir().unwrap();
+	cachefile_path.push("seme.json");
+	cachefile_path
+}
+
+fn read_cache_file() -> HashMap<String, CacheEntry> {
+	serde_json::from_str(
+		&String::from_utf8(fs::read(get_cachefile_path()).unwrap_or_default()).unwrap_or_default(),
+	)
+	.unwrap_or_default()
+}
+
+fn write_to_cache(cache: HashMap<String, CacheEntry>) -> Result<(), Error> {
+	Ok(fs::write(
+		get_cachefile_path(),
+		serde_json::to_string(&cache).unwrap_or_default(),
+	)?)
+}


### PR DESCRIPTION
As of issue #1 seme now puts a hashmap of URLs and their results into "CACHEDIR/seme.json" (on linux for example ~/.cache/seme.json). The dirs crate ensures we're writing to the OSes cache dir.  It also tracks the age of cache, if its older than a month, it gets removed.